### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # lightdash-mcp-server
+[![smithery badge](https://smithery.ai/badge/@syucream/lightdash-mcp-server)](https://smithery.ai/server/@syucream/lightdash-mcp-server)
 
 A [MCP(Model Context Protocol)](https://www.anthropic.com/news/model-context-protocol) server that accesses to [Lightdash](https://www.lightdash.com/).
 
@@ -23,6 +24,15 @@ Available tools:
 
 ### Installation
 
+#### Installing via Smithery
+
+To install Lightdash MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@syucream/lightdash-mcp-server):
+
+```bash
+npx -y @smithery/cli install @syucream/lightdash-mcp-server --client claude
+```
+
+#### Manual Installation
 ```bash
 npm install lightdash-mcp-server
 ```

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,21 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - lightdashApiKey
+    properties:
+      lightdashApiKey:
+        type: string
+        description: The API key for accessing the Lightdash API.
+      lightdashApiUrl:
+        type: string
+        default: https://app.lightdash.cloud/api/v1
+        description: The base URL for the Lightdash API.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({ command: 'npx', args: ['lightdash-mcp-server'], env: { LIGHTDASH_API_KEY: config.lightdashApiKey, LIGHTDASH_API_URL: config.lightdashApiUrl } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@syucream/lightdash-mcp-server?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂