### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A [MCP(Model Context Protocol)](https://www.anthropic.com/news/model-context-pro
 
 This server provides MCP-compatible access to Lightdash's API, allowing AI assistants to interact with your Lightdash data through a standardized interface.
 
+<a href="https://glama.ai/mcp/servers/e1gbb6sflq">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/e1gbb6sflq/badge" alt="Lightdash Server MCP server" />
+</a>
+
 ## Features
 
 Available tools:


### PR DESCRIPTION
This PR adds a badge for the [Lightdash MCP Server](https://glama.ai/mcp/servers/e1gbb6sflq) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/e1gbb6sflq">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/e1gbb6sflq/badge" alt="Lightdash Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.