### PR TITLE
Update Lightdash API base URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Create a `.env` file with your Lightdash API credentials:
 
 ```env
 LIGHTDASH_API_KEY=your_api_key
-LIGHTDASH_API_URL=https://app.lightdash.cloud/api/v1  # or your custom Lightdash instance URL
+LIGHTDASH_API_URL=https://app.lightdash.cloud  # or your custom Lightdash instance URL
 ```
 
 ### Usage

--- a/examples/list_spaces.ts
+++ b/examples/list_spaces.ts
@@ -17,7 +17,7 @@ config();
 const apiKey = process.env.EXAMPLES_CLIENT_LIGHTDASH_API_KEY;
 const apiUrl =
   process.env.EXAMPLES_CLIENT_LIGHTDASH_API_URL ??
-  'https://app.lightdash.cloud/api/v1';
+  'https://app.lightdash.cloud';
 
 if (!apiKey) {
   throw new Error(

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -13,7 +13,7 @@ startCommand:
         description: The API key for accessing the Lightdash API.
       lightdashApiUrl:
         type: string
-        default: https://app.lightdash.cloud/api/v1
+        default: https://app.lightdash.cloud
         description: The base URL for the Lightdash API.
   commandFunction:
     # A function that produces the CLI command to start the MCP on stdio.


### PR DESCRIPTION
# Update Lightdash API Base URL Configuration

## Changes
This PR updates the Lightdash API base URL configuration by removing the `/api/v1` suffix from the URL in multiple configuration files:

- README.md
- examples/list_spaces.ts
- smithery.yaml