### PR TITLE
Add streamable HTTP server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Directly:
 ```bash
 npx lightdash-mcp-server
 ```
+Specify a port with `--port` to expose a streamable HTTP endpoint instead of
+stdio. The port must be between `1024` and `65535`:
+
+```bash
+npx lightdash-mcp-server --port 3000
+```
 Or, run the installed module with node.
 
 2. Edit your MCP configuration json:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.4",
+        "@modelcontextprotocol/sdk": "^1.1.0",
         "@types/express": "^5.0.0",
         "@types/node": "^22.10.3",
         "dotenv": "^16.4.7",
@@ -311,8 +311,8 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.4.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.1.0.tgz",
       "integrity": "sha512-C+jw1lF6HSGzs7EZpzHbXfzz9rj9him4BaoumlTciW/IDDgIpweF/qiCWKlP02QKg5PPcgY6xY2WCt5y2tpYow==",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -3045,8 +3045,8 @@
       }
     },
     "@modelcontextprotocol/sdk": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.4.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.1.0.tgz",
       "integrity": "sha512-C+jw1lF6HSGzs7EZpzHbXfzz9rj9him4BaoumlTciW/IDDgIpweF/qiCWKlP02QKg5PPcgY6xY2WCt5y2tpYow==",
       "requires": {
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/syucream/lightdash-mcp-server#readme",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.4",
+    "@modelcontextprotocol/sdk": "^1.1.0",
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.3",
     "dotenv": "^16.4.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,9 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import express from 'express';
+import { parseArgs } from 'node:util';
 import { createLightdashClient } from 'lightdash-client-typescript-fetch';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import {
@@ -438,13 +441,60 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 });
 
-async function runServer() {
+async function startStdioServer() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error('Lightdash MCP Server running on stdio');
 }
 
-runServer().catch((error) => {
+async function startHttpServer(port: number) {
+  const app = express();
+  app.use(express.json({ limit: '4mb' }));
+
+  let transport: SSEServerTransport | undefined;
+
+  app.get('/sse', async (_req, res) => {
+    transport = new SSEServerTransport('/message', res);
+    await server.connect(transport);
+    console.error(
+      `Lightdash MCP Server new SSE connection ${transport.sessionId}`
+    );
+  });
+
+  app.post('/message', async (req, res) => {
+    if (!transport) {
+      res.status(404).send('Session not initialized');
+      return;
+    }
+    await transport.handlePostMessage(req, res, req.body);
+  });
+
+  app.listen(port, () => {
+    console.error(
+      `Lightdash MCP Server running on http://localhost:${port}/sse`
+    );
+  });
+}
+
+async function main() {
+  const { values } = parseArgs({ options: { port: { type: 'string' } } });
+  const portValue = values.port;
+
+  if (typeof portValue === 'string') {
+    const port = parseInt(portValue, 10);
+    if (Number.isNaN(port)) {
+      throw new Error(`Invalid port: ${portValue}`);
+    }
+    if (port < 1024 || port > 65535) {
+      throw new Error('Port must be between 1024 and 65535');
+    }
+    await startHttpServer(port);
+  } else {
+    await startStdioServer();
+  }
+}
+
+main().catch((error) => {
   console.error('Fatal error in main():', error);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- update MCP SDK to ^1.1.0
- add ability to run server either on stdio or streamable HTTP
- support `--port` command line flag to enable HTTP mode
- document `--port` flag in README
- validate port is not within well-known port range (1024-65535)

## Testing
- `npm run lint`
- `npm test`
