### PR TITLE
Add streamable HTTP server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Directly:
 ```bash
 npx lightdash-mcp-server
 ```
+Specify a port with `--port` to expose a streamable HTTP endpoint instead of
+stdio:
+
+```bash
+npx lightdash-mcp-server --port 3000
+```
 Or, run the installed module with node.
 
 2. Edit your MCP configuration json:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.4",
+        "@modelcontextprotocol/sdk": "^1.1.0",
         "@types/express": "^5.0.0",
         "@types/node": "^22.10.3",
         "dotenv": "^16.4.7",
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.4.tgz",
-      "integrity": "sha512-C+jw1lF6HSGzs7EZpzHbXfzz9rj9him4BaoumlTciW/IDDgIpweF/qiCWKlP02QKg5PPcgY6xY2WCt5y2tpYow==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.1.0.tgz",
+      "integrity": "sha512-o5PIPz0vc1bJYXS0oLvRr8yUOzYtxEFL1rWP4aiO8qLslCksmbKhONy6CTpq0WPuIXUt2YuXoRtVA2EcLix3fw==",
       "dependencies": {
         "content-type": "^1.0.5",
         "raw-body": "^3.0.0",
@@ -3045,9 +3045,9 @@
       }
     },
     "@modelcontextprotocol/sdk": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.4.tgz",
-      "integrity": "sha512-C+jw1lF6HSGzs7EZpzHbXfzz9rj9him4BaoumlTciW/IDDgIpweF/qiCWKlP02QKg5PPcgY6xY2WCt5y2tpYow==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.1.0.tgz",
+      "integrity": "sha512-o5PIPz0vc1bJYXS0oLvRr8yUOzYtxEFL1rWP4aiO8qLslCksmbKhONy6CTpq0WPuIXUt2YuXoRtVA2EcLix3fw==",
       "requires": {
         "content-type": "^1.0.5",
         "raw-body": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/syucream/lightdash-mcp-server#readme",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.4",
+    "@modelcontextprotocol/sdk": "^1.1.0",
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.3",
     "dotenv": "^16.4.7",


### PR DESCRIPTION
## Summary
- update MCP SDK to ^1.1.0
- add ability to run server either on stdio or streamable HTTP
- support `--port` command line flag to enable HTTP mode
- document `--port` flag in README
- fix npm lockfile integrity

## Testing
- `npm run lint`
- `npm test`
